### PR TITLE
feat: implement dashboard block with compliance metrics

### DIFF
--- a/src/components/dashboard/overview.tsx
+++ b/src/components/dashboard/overview.tsx
@@ -1,0 +1,50 @@
+import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "../ui/chart";
+
+const chartData = [
+  { month: "Jan", completed: 18 },
+  { month: "Feb", completed: 24 },
+  { month: "Mar", completed: 32 },
+  { month: "Apr", completed: 40 },
+  { month: "May", completed: 38 },
+  { month: "Jun", completed: 55 },
+];
+
+const chartConfig = {
+  completed: {
+    label: "Tasks Completed",
+    color: "hsl(var(--chart-1))",
+  },
+};
+
+export function Overview() {
+  return (
+    <ChartContainer config={chartConfig} className="mt-6">
+      <AreaChart data={chartData}>
+        <CartesianGrid strokeDasharray="4 4" className="stroke-muted" />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          className="text-xs"
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator="line" />} />
+        <Area
+          dataKey="completed"
+          type="monotone"
+          fill="var(--color-completed)"
+          stroke="var(--color-completed)"
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+

--- a/src/components/dashboard/recent-activity.tsx
+++ b/src/components/dashboard/recent-activity.tsx
@@ -1,0 +1,50 @@
+import { Avatar, AvatarFallback } from "../ui/avatar";
+
+const activities = [
+  {
+    user: "Alex Johnson",
+    action: "Logged sterilizer calibration",
+    initials: "AJ",
+    time: "2h ago",
+  },
+  {
+    user: "Maria Chen",
+    action: "Completed safety inspection",
+    initials: "MC",
+    time: "1d ago",
+  },
+  {
+    user: "Sam Patel",
+    action: "Filed incident report",
+    initials: "SP",
+    time: "3d ago",
+  },
+  {
+    user: "Lisa Wong",
+    action: "Updated compliance checklist",
+    initials: "LW",
+    time: "1w ago",
+  },
+];
+
+export function RecentActivity() {
+  return (
+    <div className="space-y-8">
+      {activities.map((item) => (
+        <div key={item.user + item.time} className="flex items-center">
+          <Avatar className="h-9 w-9">
+            <AvatarFallback>{item.initials}</AvatarFallback>
+          </Avatar>
+          <div className="ml-4 space-y-1">
+            <p className="text-sm font-medium leading-none">{item.user}</p>
+            <p className="text-sm text-muted-foreground">{item.action}</p>
+          </div>
+          <div className="ml-auto font-medium text-sm">
+            {item.time}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,29 +2,122 @@ import {
   Card,
   CardHeader,
   CardTitle,
+  CardDescription,
   CardContent,
 } from "../components/ui/card";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "../components/ui/tabs";
+import { Button } from "../components/ui/button";
+import {
+  Wrench,
+  ClipboardCheck,
+  CheckCircle,
+  Bell,
+} from "lucide-react";
+import { Overview } from "../components/dashboard/overview";
+import { RecentActivity } from "../components/dashboard/recent-activity";
 
 export default function Dashboard() {
-  const stats = [
-    { label: "Total Users", value: 42 },
-    { label: "Departments", value: 5 },
-    { label: "Active Checklists", value: 23 },
-    { label: "Equipment", value: 12 },
-  ];
-
   return (
-    <div className="p-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      {stats.map((stat) => (
-        <Card key={stat.label}>
-          <CardHeader>
-            <CardTitle>{stat.label}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{stat.value}</div>
-          </CardContent>
-        </Card>
-      ))}
+    <div className="flex-col md:flex">
+      <div className="flex-1 space-y-4 p-6 pt-4 md:p-8 md:pt-6">
+        <div className="flex items-center justify-between space-y-2">
+          <h2 className="text-3xl font-bold tracking-tight">Dashboard</h2>
+          <div className="flex items-center space-x-2">
+            <Button>Download</Button>
+          </div>
+        </div>
+        <Tabs defaultValue="overview" className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="reports" disabled>
+              Reports
+            </TabsTrigger>
+            <TabsTrigger value="notifications" disabled>
+              Notifications
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="overview" className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Pending Maintenance
+                  </CardTitle>
+                  <Wrench className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">18</div>
+                  <p className="text-xs text-muted-foreground">
+                    +3 since last week
+                  </p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Compliance Tasks Due
+                  </CardTitle>
+                  <ClipboardCheck className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">12</div>
+                  <p className="text-xs text-muted-foreground">Due this week</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Inspections Completed
+                  </CardTitle>
+                  <CheckCircle className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">32</div>
+                  <p className="text-xs text-muted-foreground">+8 this month</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Equipment Alerts
+                  </CardTitle>
+                  <Bell className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">4</div>
+                  <p className="text-xs text-muted-foreground">
+                    +1 since yesterday
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
+              <Card className="col-span-4">
+                <CardHeader>
+                  <CardTitle>Maintenance Overview</CardTitle>
+                  <CardDescription>
+                    Tasks completed over the last six months
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="pl-2">
+                  <Overview />
+                </CardContent>
+              </Card>
+              <Card className="col-span-3">
+                <CardHeader>
+                  <CardTitle>Recent Activity</CardTitle>
+                  <CardDescription>
+                    Latest compliance actions
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <RecentActivity />
+                </CardContent>
+              </Card>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- integrate shadcn `dashboard-01` block on homepage
- add maintenance overview chart and recent compliance activity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b01ebc41c08326881dc28b59c0e956