### PR TITLE
Improve mobile responsiveness across pages

### DIFF
--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -106,8 +106,8 @@ export function DataTable<TData, TValue>({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <div className="rounded-md border">
-        <Table>
+      <div className="w-full overflow-x-auto rounded-md border">
+        <Table className="w-full">
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>

--- a/src/pages/Checklists.tsx
+++ b/src/pages/Checklists.tsx
@@ -67,10 +67,10 @@ export default function Checklists() {
     return (
       <div className="container mx-auto p-4 sm:p-6 lg:p-8">
         {/* Toolbar Skeleton */}
-        <div className="flex items-center justify-between gap-3 mb-6">
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-10 w-64" />
-            <Skeleton className="h-10 w-[180px]" />
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
+            <Skeleton className="h-10 w-full sm:w-64" />
+            <Skeleton className="h-10 w-full sm:w-[180px]" />
           </div>
         </div>
         {/* Grid Skeleton */}
@@ -95,19 +95,19 @@ export default function Checklists() {
   return (
     <div className="container mx-auto p-4 sm:p-6 lg:p-8">
       {/* Toolbar */}
-      <div className="flex items-center justify-between gap-3 mb-6">
-        <div className="flex items-center gap-2">
-          <div className="relative">
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:gap-2">
+          <div className="relative flex-1">
             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search checklists..."
-              className="w-64 pl-9"
+              className="w-full pl-9 sm:w-64"
             />
           </div>
           <Select onValueChange={(value) => setSortBy(value as any)} defaultValue={sortBy}>
-            <SelectTrigger className="w-[180px]">
+            <SelectTrigger className="w-full sm:w-[180px]">
               <SelectValue placeholder="Sort by..." />
             </SelectTrigger>
             <SelectContent>

--- a/src/pages/Departments.tsx
+++ b/src/pages/Departments.tsx
@@ -16,25 +16,27 @@ const departments = [
 
 export default function Departments() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Departments</h1>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Manager</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {departments.map((dept) => (
-            <TableRow key={dept.name}>
-              <TableCell>{dept.name}</TableCell>
-              <TableCell>{dept.manager}</TableCell>
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <h1 className="mb-4 text-2xl font-semibold">Departments</h1>
+      <div className="overflow-x-auto">
+        <Table className="w-full">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Manager</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-        <TableCaption>A list of company departments.</TableCaption>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {departments.map((dept) => (
+              <TableRow key={dept.name}>
+                <TableCell>{dept.name}</TableCell>
+                <TableCell>{dept.manager}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+          <TableCaption>A list of company departments.</TableCaption>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/src/pages/Equipment.tsx
+++ b/src/pages/Equipment.tsx
@@ -16,27 +16,29 @@ const equipment = [
 
 export default function Equipment() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Equipment</h1>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Model</TableHead>
-            <TableHead>Status</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {equipment.map((item) => (
-            <TableRow key={item.model}>
-              <TableCell>{item.name}</TableCell>
-              <TableCell>{item.model}</TableCell>
-              <TableCell>{item.status}</TableCell>
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <h1 className="mb-4 text-2xl font-semibold">Equipment</h1>
+      <div className="overflow-x-auto">
+        <Table className="w-full">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Model</TableHead>
+              <TableHead>Status</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-        <TableCaption>A list of equipment in the system.</TableCaption>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {equipment.map((item) => (
+              <TableRow key={item.model}>
+                <TableCell>{item.name}</TableCell>
+                <TableCell>{item.model}</TableCell>
+                <TableCell>{item.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+          <TableCaption>A list of equipment in the system.</TableCaption>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/src/pages/Logs.tsx
+++ b/src/pages/Logs.tsx
@@ -31,27 +31,29 @@ const logs = [
 
 export default function Logs() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Logs</h1>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Time</TableHead>
-            <TableHead>User</TableHead>
-            <TableHead>Action</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {logs.map((log) => (
-            <TableRow key={log.id}>
-              <TableCell>{log.time}</TableCell>
-              <TableCell>{log.user}</TableCell>
-              <TableCell>{log.action}</TableCell>
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <h1 className="mb-4 text-2xl font-semibold">Logs</h1>
+      <div className="overflow-x-auto">
+        <Table className="w-full">
+          <TableHeader>
+            <TableRow>
+              <TableHead>Time</TableHead>
+              <TableHead>User</TableHead>
+              <TableHead>Action</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-        <TableCaption>A log of recent activities.</TableCaption>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {logs.map((log) => (
+              <TableRow key={log.id}>
+                <TableCell>{log.time}</TableCell>
+                <TableCell>{log.user}</TableCell>
+                <TableCell>{log.action}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+          <TableCaption>A log of recent activities.</TableCaption>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 function NotFound() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background px-6 text-center">
-      <h1 className="text-6xl font-bold text-foreground">404</h1>
+      <h1 className="text-4xl font-bold text-foreground sm:text-6xl">404</h1>
       <p className="mt-2 text-lg text-muted-foreground">Oops! Page not found.</p>
       <Link to="/" className="mt-6">
         <Button>Go back home</Button>

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -20,16 +20,14 @@ const reports = [
 
 export default function Reports() {
   return (
-    <div className="p-6 grid gap-4 sm:grid-cols-2">
+    <div className="container mx-auto grid gap-4 p-4 sm:grid-cols-2 sm:p-6 lg:p-8">
       {reports.map((report) => (
         <Card key={report.id}>
           <CardHeader>
             <CardTitle>{report.title}</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground">
-              {report.description}
-            </p>
+            <p className="text-sm text-muted-foreground">{report.description}</p>
           </CardContent>
         </Card>
       ))}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,9 +9,9 @@ export default function SettingsPage() {
   const [notifications, setNotifications] = useState(true);
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Settings</h1>
-      <div className="space-y-4 max-w-md">
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <h1 className="mb-4 text-2xl font-semibold">Settings</h1>
+      <div className="max-w-md space-y-4">
         <div className="space-y-2">
           <Label htmlFor="email">Email</Label>
           <Input

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -2,9 +2,11 @@ import UserTable from "../components/tables/UserTable";
 
 export default function UsersPage() {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4">Users</h1>
-      <UserTable />
+    <div className="container mx-auto p-4 sm:p-6 lg:p-8">
+      <h1 className="mb-4 text-2xl font-semibold">Users</h1>
+      <div className="overflow-x-auto">
+        <UserTable />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap table-based pages in responsive containers and enable horizontal scrolling for small screens
- Make checklist filters and skeleton layout stack on mobile
- Scale 404 heading and ensure DataTable supports overflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-alert-dialog)*
- `npm run build` *(fails: dotenvx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02134db0c8326bee24c14bb38f770